### PR TITLE
Do not call `virtualenv` executable directly

### DIFF
--- a/hatch/venv.py
+++ b/hatch/venv.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import shutil
 import subprocess
 from contextlib import contextmanager
@@ -75,7 +76,8 @@ def get_available_venvs():
 
 
 def create_venv(d, pypath=None, verbose=False):
-    command = ['virtualenv', d, '-p', pypath or get_python_path()]
+    command = [sys.executable, '-m', 'virtualenv', d,
+               '-p', pypath or get_python_path()]
     if not verbose:  # no cov
         command.append('--quiet')
     subprocess.run(command, shell=NEED_SUBPROCESS_SHELL)


### PR DESCRIPTION
Hello.

I am trying to package Hatch to Fedora and I found one issue.

The problem is that in some Linux distribution where the default Python is still Python 2 you should avoid calling tools like `virtualenv` directly because `virtualenv` without `-3` suffix means Python 2 virtualenv. And because Hatch is Python3-only there is no `virtualenv` command available in build environment during building RPM package.

Moreover when you use `sys.executable` you can be sure that the same Python will be used for virtualenv like it is for running Hatch.

What do you think about it?