### PR TITLE
Support Fedora packaging

### DIFF
--- a/tests/commands/test_env.py
+++ b/tests/commands/test_env.py
@@ -13,6 +13,7 @@ from hatch.settings import (
 )
 from hatch.utils import copy_path, remove_path, temp_chdir, temp_move_path
 from hatch.venv import VENV_DIR, create_venv, get_new_venv_name, venv
+from ..utils import requires_internet
 
 
 def test_success():
@@ -192,6 +193,7 @@ def test_clone_venv_not_exist():
         assert 'Virtual env `{name}` does not exist.'.format(name=env_name) in result.output
 
 
+@requires_internet
 def test_clone_success():
     with temp_chdir():
         runner = CliRunner()
@@ -220,6 +222,7 @@ def test_clone_success():
         assert 'six' in installed_packages
 
 
+@requires_internet
 def test_restore_success():
     with temp_chdir() as d:
         runner = CliRunner()

--- a/tests/commands/test_install.py
+++ b/tests/commands/test_install.py
@@ -6,6 +6,7 @@ from hatch.cli import hatch
 from hatch.env import get_editable_packages, get_installed_packages
 from hatch.utils import remove_path, temp_chdir
 from hatch.venv import VENV_DIR, create_venv, get_new_venv_name, venv
+from ..utils import requires_internet
 
 
 def test_local():
@@ -52,6 +53,7 @@ def test_local_none():
         assert result.exit_code != 0
 
 
+@requires_internet
 def test_packages():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -77,6 +79,7 @@ def test_env_not_exist():
         assert 'Virtual env named `{}` does not exist.'.format(env_name) in result.output
 
 
+@requires_internet
 def test_env():
     with temp_chdir():
         runner = CliRunner()

--- a/tests/commands/test_release.py
+++ b/tests/commands/test_release.py
@@ -7,12 +7,14 @@ from hatch.env import install_packages
 from hatch.settings import SETTINGS_FILE, copy_default_settings, save_settings
 from hatch.utils import env_vars, temp_chdir, temp_move_path
 from hatch.venv import create_venv, venv
+from ..utils import requires_internet
 
 PACKAGE_NAME = 'e00f69943529ccc38058'
 USERNAME = 'Ofekmeister'
 ENV_VARS = {'TWINE_PASSWORD': 'badpwbestpw'}
 
 
+@requires_internet
 def test_cwd():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -26,6 +28,7 @@ def test_cwd():
         assert result.exit_code == 0
 
 
+@requires_internet
 def test_cwd_dist_exists():
     with temp_chdir():
         runner = CliRunner()
@@ -38,6 +41,7 @@ def test_cwd_dist_exists():
         assert result.exit_code == 0
 
 
+@requires_internet
 def test_package():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -71,6 +75,7 @@ def test_package_not_exist():
         assert '`{}` is not an editable package.'.format(PACKAGE_NAME) in result.output
 
 
+@requires_internet
 def test_path_relative():
     with temp_chdir():
         runner = CliRunner()
@@ -84,6 +89,7 @@ def test_path_relative():
         assert result.exit_code == 0
 
 
+@requires_internet
 def test_path_full():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -111,6 +117,7 @@ def test_path_full_not_exist():
         assert 'Directory `{}` does not exist.'.format(full_path) in result.output
 
 
+@requires_internet
 def test_config_username():
     with temp_chdir() as d:
         runner = CliRunner()

--- a/tests/commands/test_uninstall.py
+++ b/tests/commands/test_uninstall.py
@@ -6,8 +6,10 @@ from hatch.cli import hatch
 from hatch.env import get_installed_packages
 from hatch.utils import remove_path, temp_chdir
 from hatch.venv import VENV_DIR, create_venv, get_new_venv_name, venv
+from ..utils import requires_internet
 
 
+@requires_internet
 def test_requirements():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -38,6 +40,7 @@ def test_requirements_none():
         assert 'Unable to locate a requirements file.' in result.output
 
 
+@requires_internet
 def test_packages():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -64,6 +67,7 @@ def test_env_not_exist():
         assert 'Virtual env named `{}` does not exist.'.format(env_name) in result.output
 
 
+@requires_internet
 def test_env():
     with temp_chdir():
         runner = CliRunner()

--- a/tests/commands/test_update.py
+++ b/tests/commands/test_update.py
@@ -9,8 +9,10 @@ from hatch.env import (
 from hatch.utils import remove_path, temp_chdir
 from hatch.venv import VENV_DIR, create_venv, get_new_venv_name, venv
 from ..utils import get_version_as_bytes
+from ..utils import requires_internet
 
 
+@requires_internet
 def test_requirements():
     with temp_chdir() as d:
         with open(os.path.join(d, 'requirements.txt'), 'w') as f:
@@ -30,6 +32,7 @@ def test_requirements():
         assert initial_version < final_version
 
 
+@requires_internet
 def test_dev_requirements():
     with temp_chdir() as d:
         with open(os.path.join(d, 'dev-requirements.txt'), 'w') as f:
@@ -49,6 +52,7 @@ def test_dev_requirements():
         assert initial_version < final_version
 
 
+@requires_internet
 def test_requirements_dev():
     with temp_chdir() as d:
         with open(os.path.join(d, 'requirements-dev.txt'), 'w') as f:
@@ -68,6 +72,7 @@ def test_requirements_dev():
         assert initial_version < final_version
 
 
+@requires_internet
 def test_requirements_includes_hatch():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -102,6 +107,7 @@ def test_requirements_none():
         assert 'Unable to locate a requirements file.' in result.output
 
 
+@requires_internet
 def test_packages():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -130,6 +136,7 @@ def test_packages_only_hatch():
         assert 'No packages to install.' in result.output
 
 
+@requires_internet
 def test_all_packages():
     with temp_chdir() as d:
         venv_dir = os.path.join(d, 'venv')
@@ -173,6 +180,7 @@ def test_env_not_exist():
         assert 'Virtual env named `{}` does not exist.'.format(env_name) in result.output
 
 
+@requires_internet
 def test_env():
     with temp_chdir():
         runner = CliRunner()
@@ -195,6 +203,7 @@ def test_env():
         assert initial_version < final_version
 
 
+@requires_internet
 def test_infra():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -211,6 +220,7 @@ def test_infra():
         assert initial_version < final_version
 
 
+@requires_internet
 def test_infra_env():
     with temp_chdir():
         runner = CliRunner()

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -9,12 +9,14 @@ from hatch.env import (
 )
 from hatch.utils import temp_chdir
 from hatch.venv import create_venv, venv
+from .utils import requires_internet
 
 
 def test_get_package_version_not_installed():
     assert get_package_version('the_knights_who_say_ni') == ''
 
 
+@requires_internet
 def test_get_installed_packages_no_editable():
     with temp_chdir() as d:
         runner = CliRunner()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,6 @@
 import re
+import socket
+import pytest
 
 from hatch.env import get_package_version
 
@@ -19,3 +21,18 @@ def matching_file(pattern, files):
         if re.search(pattern, file):
             return True
     return False
+
+
+def connected_to_internet():  # no cov
+    try:
+        # Test availability of DNS first
+        host = socket.gethostbyname('www.google.com')
+        # Test connection
+        s = socket.create_connection((host, 80), 2)
+        return True
+    except Exception:
+        return False
+
+
+requires_internet = pytest.mark.skipif(not connected_to_internet(),
+                                       reason="Not connected to internet")

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,6 @@ deps =
     parse
 commands =
     python setup.py --quiet clean develop
-    coverage run --parallel-mode -m pytest
+    coverage run --parallel-mode -m pytest {posargs}
     coverage combine --append
     coverage report -m


### PR DESCRIPTION
- skip tests which require an internet connection when it is not available
- install `pytest` into the ok package in `test_package` and run `pytest` as a module inside the package (this make the test depends on internet connection)

With these changes, I am able to run build of RPM for Fedora and also all tests are passing on my local machine.

If you are ok with these changes, please merge it and release a new version so I can build the newest specfile for RPM on it and send it to package review.