### PR TITLE
python command for OS X

### DIFF
--- a/hatch/exceptions.py
+++ b/hatch/exceptions.py
@@ -1,2 +1,8 @@
 class InvalidVirtualEnv(Exception):
     pass
+
+class PythonPkgNotInstalled(Exception):
+    pass
+
+class PkgInstallerSystemProblem(Exception):
+    pass

--- a/hatch/interpreters_osx.py
+++ b/hatch/interpreters_osx.py
@@ -6,15 +6,6 @@ from hatch.exceptions import PythonPkgNotInstalled, PkgInstallerSystemProblem
 
 ENCODING = 'utf-8'
 
-# reinstall = 'pip3.5 uninstall hatch & cd ~/PycharmProjects/hatch && python3.5 setup.py install'
-#
-# example = 'org.python.Python.PythonApplications-3.4'
-# example_installer_path = '~/Downloads/python-3.4.4-macosx10.6.pkg'
-# ex = 'cd /Applications'
-# delete_files_ex = "pkgutil --only-files --files org.python.Python.PythonApplications-3.4 | tr '\n' '\0' | xargs -n 1 -0 sudo rm -rf"
-# delete_dirs_ex = "pkgutil --only-dirs --files org.python.Python.PythonApplications-3.4 | tail -r | tr '\n' '\0' | xargs -n 1 -0 sudo rmdir"
-# forget_ex = "sudo pkgutil --forget org.python.Python.PythonApplications-3.4"
-
 PYTHON_PKGS = {
     'app': 'org.python.Python.PythonApplications-',
     'docs': 'org.python.Python.PythonDocumentation-',

--- a/hatch/interpreters_osx.py
+++ b/hatch/interpreters_osx.py
@@ -1,0 +1,115 @@
+import os
+import re
+import subprocess
+import requests
+from hatch.exceptions import PythonPkgNotInstalled, PkgInstallerSystemProblem
+
+ENCODING = 'utf-8'
+
+# reinstall = 'pip3.5 uninstall hatch & cd ~/PycharmProjects/hatch && python3.5 setup.py install'
+#
+# example = 'org.python.Python.PythonApplications-3.4'
+# example_installer_path = '~/Downloads/python-3.4.4-macosx10.6.pkg'
+# ex = 'cd /Applications'
+# delete_files_ex = "pkgutil --only-files --files org.python.Python.PythonApplications-3.4 | tr '\n' '\0' | xargs -n 1 -0 sudo rm -rf"
+# delete_dirs_ex = "pkgutil --only-dirs --files org.python.Python.PythonApplications-3.4 | tail -r | tr '\n' '\0' | xargs -n 1 -0 sudo rmdir"
+# forget_ex = "sudo pkgutil --forget org.python.Python.PythonApplications-3.4"
+
+PYTHON_PKGS = {
+    'app': 'org.python.Python.PythonApplications-',
+    'docs': 'org.python.Python.PythonDocumentation-',
+    'framework': 'org.python.Python.PythonFramework-',
+    'tools': 'org.python.Python.PythonUnixTools-'
+}
+
+PYTHON_PKGS_DEFAULT_PATHS = {
+    'framework': '/Library/Frameworks/Python.framework'
+}
+
+DEVNULL = open(os.devnull, 'w')
+
+
+def gen_installers_list():
+    ver_to_link = {}
+    html = requests.get('https://www.python.org/downloads/mac-osx/').text
+    lined = html.split('\n')
+    instlr_link_re = re.compile('.*<li>Download <a href="(.+)?">.*64-bit\/32-bit installer.*')
+    #TODO: Separate install options for x32 builds?
+    ver_re = re.compile('.*python-(.*?)-')
+    for li in lined:
+        try:
+            link = instlr_link_re.match(li).groups(1)[0]
+            ver = ver_re.match(link).groups(1)[0]
+            ver_to_link[ver] = link
+        except AttributeError:
+            pass
+    return ver_to_link
+
+
+def strip_build_ver(version):
+    return '.'.join(version.split('.')[:-1])
+
+
+def py_framework_path(stripped_ver):
+    return pkg_path(PYTHON_PKGS['framework'] + stripped_ver)
+
+
+def is_pkgs_installed(stripped_ver):
+    for pkg in PYTHON_PKGS.values():
+        command = ['pkgutil', '--pkgs=%s%s' % (pkg, stripped_ver)]
+        res = subprocess.run(command, stdout=DEVNULL)
+        if res.returncode:
+            return False
+    else:
+        return True
+
+
+def pkg_path(pkg):
+    command = ['pkgutil', '--pkg-info=%s' % pkg]
+    res = subprocess.run(command, stdout=subprocess.PIPE)
+    if res.returncode:
+        raise PythonPkgNotInstalled('{} is not installed!'.format(pkg))
+
+    out = res.stdout.decode(ENCODING)
+    splitted = out.split('\n')
+    vol = splitted[2][8:]  # strip 'volume: '
+    loc = splitted[3][10:]  # strip 'location: '
+    return vol + loc
+
+
+def install_interpreter(pkg_path):
+    command = ['sudo -S installer -pkg %s -target /' % pkg_path]
+    res = subprocess.run(command, stdout=subprocess.PIPE, shell=True)
+    if res.returncode:
+        raise PkgInstallerSystemProblem('Problem installing package %s' % pkg_path)
+
+
+def uninstall_pkg(pkg):
+    path = pkg_path(pkg)
+    os.chdir(path)
+    delete_files = "pkgutil --only-files --files {}" \
+                   " | tr '\n' '\\0'" \
+                   " | xargs -n 1 -0 sudo rm -rf".format(pkg)
+    subprocess.run(delete_files, stdout=DEVNULL, shell=True)
+
+    delete_dirs = "pkgutil --only-dirs --files {}" \
+                  " | tail -r" \
+                  " | tr '\n' '\\0' | xargs -n 1 -0 sudo rmdir".format(pkg)
+    subprocess.run(delete_dirs, stdout=DEVNULL, stderr=DEVNULL, shell=True)
+
+    forget_pkg = "sudo pkgutil --forget {}".format(pkg)
+    subprocess.run(forget_pkg, stdout=DEVNULL, shell=True)
+
+
+def download_python_pkg(version):
+    PYTHON_PKG_LINKS = gen_installers_list()
+    #TODO: Caching in file?
+    resp = requests.get(PYTHON_PKG_LINKS[version], stream=True)
+    downloads = os.path.expanduser('~/Downloads')
+    pkg_name = PYTHON_PKG_LINKS[version].split('/')[-1]
+    os.chdir(downloads)
+    with open(pkg_name, 'wb') as f:
+        for chunk in resp:
+            f.write(chunk)
+    del resp
+    return os.path.join(downloads, pkg_name)

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,8 @@ setup(
         'setuptools>=36.0.0',
         'twine>=1.9.1',
         'virtualenv',
-        'wheel>=0.27.0'
+        'wheel>=0.27.0',
+        'requests'
     ),
     setup_requires=('appdirs', 'atomicwrites'),
     tests_require=('parse', ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import sys
+import pytest
+
+ALL = set("darwin linux win".split())
+
+def pytest_runtest_setup(item):
+    if isinstance(item, item.Function):
+        plat = sys.platform
+        if not item.get_marker(plat):
+            if ALL.intersection(item.keywords):
+                pytest.skip("cannot run on platform %s" %(plat))

--- a/tests/test_install_interpreter_osx.py
+++ b/tests/test_install_interpreter_osx.py
@@ -1,0 +1,54 @@
+import pytest
+from click.testing import CliRunner
+from hatch.cli import hatch
+from hatch.interpreters_osx import PYTHON_PKGS_DEFAULT_PATHS, strip_build_ver, ENCODING, is_pkgs_installed
+import subprocess
+
+"""
+Allow no sudo passwd for tests
+sudo echo "$USER  ALL=(ALL) NOPASSWD:/usr/sbin/pkgutil,/bin/rmdir,/bin/rm,/usr/sbin/installer" | sudo tee -a /etc/sudoers
+"""
+
+RUNNER = CliRunner()
+
+def install_python(ver):
+    return RUNNER.invoke(hatch, ['python', ver])
+
+def uninstall_python(ver):
+    return RUNNER.invoke(hatch, ['python', ver, '--rm'])
+
+def runtime(ver):
+    command = [PYTHON_PKGS_DEFAULT_PATHS['framework'] +
+               '/Versions/' + strip_build_ver(ver) +
+               '/bin/python' + strip_build_ver(ver) + ' -c "import sys; print(sys.executable)"']
+
+    installed_in_paths = [
+        '/Library/Frameworks/Python.framework/Versions/' \
+        + strip_build_ver(ver) + \
+        '/bin/python' + strip_build_ver(ver) + '\n',
+
+        '/Library/Frameworks/Python.framework/Versions/'
+        + strip_build_ver(ver) + '/Resources/Python.app/Contents/MacOS/Python' + '\n'
+    ] #TODO: What is the problem behind installing some versions of python as app, and some as Framework?
+      #TODO: Check DEFAULT symlinks is not changed, for example 2.7.14rc1 changes python2.7 symlink
+    return any([subprocess.run(command,
+                          stdout=subprocess.PIPE,
+                          shell=True).stdout.decode(ENCODING) in installed_in_paths])
+
+
+def no_runtime(ver):
+    command = [PYTHON_PKGS_DEFAULT_PATHS['framework'] +
+               '/Versions/' + strip_build_ver(ver) +
+               '/bin/python' + strip_build_ver(ver) + ' -c "import sys; print(sys.executable)"']
+    return 127 == subprocess.run(command,
+                                 stdout=subprocess.PIPE,
+                                 shell=True).returncode
+
+@pytest.mark.darwin
+@pytest.mark.parametrize('ver', ['3.6.0', '2.7.14rc1'])
+def test_install_uninstall_python(ver):
+    install_python(ver)
+    assert runtime(ver)
+    assert uninstall_python(ver).exit_code == 0
+    assert no_runtime(ver)
+    assert not is_pkgs_installed(ver)


### PR DESCRIPTION
Hello!
Please review initial implementation of "python" command for now only for **OS X**.
You can install any package from https://www.python.org/downloads/mac-osx/ using **/usr/sbin/installer** and uninstall it correctly using **pkgutil**
Initial test for 2.x and 3.x is here, you can make branch if it's ok, and I'll test it thoroughly and implement todos, or let me know if it should be refactored.

```
10723 ◯  hatch python 3.6.0
Downloading python 3.6.0 from python.org...
Saved installer in /Users/a1/Downloads/python-3.6.0-macosx10.6.pkg
Installing interpreter (may require your sudo password)...
Interpreter installed in /Library/Frameworks/Python.framework
MacBooks-MacBook-Pro-2 ॐ  ~:
10724 ◯  python3.6 -c "import sys; print(sys.executable)"
/usr/local/bin/python3.6
MacBooks-MacBook-Pro-2 ॐ  ~:
10725 ◯  python3.6
Python 3.6.0 (v3.6.0:41df79263a11, Dec 22 2016, 17:23:13)
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> quit()
MacBooks-MacBook-Pro-2 ॐ  ~:
10726 ◯  hatch python 3.6.0 --rm
Uninstalling python in /Library/Frameworks/Python.framework/3.6
MacBooks-MacBook-Pro-2 ॐ  ~:
10727 ◯  python3.6
zsh: command not found: python3.6
MacBooks-MacBook-Pro-2 ॐ  ~:
10728 ◯
```