### PR TITLE
Support Releases to Alternative Repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 dist/
 docs/build/
 wheelhouse/
+venv/

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,3 +13,4 @@ Any PGP key fingerprints are enclosed in parentheses.
 - Ofek Lev <ofekmeister@gmail.com> (FFB6 B92B 30B1 7848 546E 9912 972F E913 DAD5 A46E)
 - Amjith Ramanujam `@amjithr <https://twitter.com/amjithr>`_
 - Lumír 'Frenzy' Balhar <frenzy.madness@gmail.com> `@lumirbalhar <https://twitter.com/lumirbalhar>`_
+- Philip Blair <philip@pblair.org>

--- a/hatch/commands/release.py
+++ b/hatch/commands/release.py
@@ -23,13 +23,13 @@ from hatch.utils import NEED_SUBPROCESS_SHELL, resolve_path
 @click.option('-p', '--path',
               help='A relative or absolute path to a build directory.')
 @click.option('-u', '--username', help='The PyPI username to use.')
-@click.option('-r', '--repository',
+@click.option('-r', '--repo',
               help=(
                   'The PyPI repository to use (default: {}). '
                   'Should be a section in the .pypirc file. '
                   '(Can also be set via TWINE_REPOSITORY environment variable)'
               ).format(DEFAULT_REPOSITORY))
-@click.option('--repository-url',
+@click.option('-ru', '--repo-url',
               help=(
                   'The repository URL to upload the package to. '
                   'This overrides --repository. '
@@ -39,7 +39,7 @@ from hatch.utils import NEED_SUBPROCESS_SHELL, resolve_path
               help='Uses the test version of PyPI. Equivalent to \'-r {}\''.format(TEST_REPOSITORY))
 @click.option('-s', '--strict', is_flag=True,
               help='Aborts if a distribution already exists.')
-def release(package, local, path, username, repository, repository_url, test_pypi, strict):
+def release(package, local, path, username, repo, repo_url, test_pypi, strict):
     """Uploads all files in a directory to PyPI using Twine.
 
     The path to the build directory is derived in the following order:
@@ -120,11 +120,11 @@ def release(package, local, path, username, repository, repository_url, test_pyp
         # Disallow these combinations, since it is ambiguous whether they are intended
         # to be used as the test repository (if a custom test repository is desired,
         # then users can omit the '--test'.)
-        if repository:
-            echo_failure('Cannot specify both --test and --repository.')
+        if repo:
+            echo_failure('Cannot specify both --test and --repo.')
             any_failed = True
-        if repository_url:
-            echo_failure('Cannot specify both --test and --repository-url.')
+        if repo_url:
+            echo_failure('Cannot specify both --test and --repo-url.')
             any_failed = True
         if any_failed:
             sys.exit(1)
@@ -132,10 +132,10 @@ def release(package, local, path, username, repository, repository_url, test_pyp
     else:  # no cov
         # Only pass these to twine if they are given to us. Otherwise,
         # fall back onto the default twine behavior
-        if repository:
-            command.extend(['-r', repository])
-        if repository_url:
-            command.extend(['--repository-url', repository_url])
+        if repo:
+            command.extend(['-r', repo])
+        if repo_url:
+            command.extend(['--repository-url', repo_url])
 
     if not strict:
         command.append('--skip-existing')

--- a/tests/commands/test_release.py
+++ b/tests/commands/test_release.py
@@ -286,7 +286,7 @@ def test_repository_url_local():
         with venv(venv_dir, evars=ENV_VARS):
             install_packages(['-e', package_dir])
             result = runner.invoke(hatch, ['release', '-l', '-u', USERNAME,
-                                           '--repository-url', TEST_REPOSITORY])
+                                           '--repo-url', TEST_REPOSITORY])
 
         assert result.exit_code == 0
 
@@ -305,8 +305,8 @@ def test_repository_and_repository_url_local():
         with venv(venv_dir, evars=ENV_VARS):
             install_packages(['-e', package_dir])
             result = runner.invoke(hatch, ['release', '-l', '-u', USERNAME,
-                                           '--repository', TEST_REPOSITORY,
-                                           '--repository-url', TEST_REPOSITORY])
+                                           '--repo', TEST_REPOSITORY,
+                                           '--repo-url', TEST_REPOSITORY])
 
         assert result.exit_code == 0
 
@@ -346,22 +346,22 @@ def test_repository_and_test():
                                            '-t'])
 
         assert result.exit_code == 1
-        assert "Cannot specify both --test and --repository." in result.output
+        assert "Cannot specify both --test and --repo." in result.output
 
         with venv(venv_dir, evars=ENV_VARS):
             result = runner.invoke(hatch, ['release', '-l', '-u', USERNAME,
-                                           '--repository-url', TEST_REPOSITORY,
+                                           '--repo-url', TEST_REPOSITORY,
                                            '-t'])
 
         assert result.exit_code == 1
-        assert "Cannot specify both --test and --repository-url." in result.output
+        assert "Cannot specify both --test and --repo-url." in result.output
 
         with venv(venv_dir, evars=ENV_VARS):
             result = runner.invoke(hatch, ['release', '-l', '-u', USERNAME,
                                            '-r', TEST_REPOSITORY,
-                                           '--repository-url', TEST_REPOSITORY,
+                                           '-ru', TEST_REPOSITORY,
                                            '-t'])
 
         assert result.exit_code == 1
-        assert "Cannot specify both --test and --repository." in result.output
-        assert "Cannot specify both --test and --repository-url." in result.output
+        assert "Cannot specify both --test and --repo." in result.output
+        assert "Cannot specify both --test and --repo-url." in result.output


### PR DESCRIPTION
## Description
This PR attempts to address #33 by making two changes to `hatch release`:
- First and foremost, this adds two flags: `-r/--repository` and `--repository-url`. These are simply passed through to `twine`. If they are not given, the `twine` default behavior will be used. For simplicity, it is an error to use these flags in combination with `-t` (since it is not immediately clear whether `-t` should override `-r` and `--repository-url`, or the other way around).
- Additionally, the behavior of `hatch release` has been changed such that it works correctly with the `TWINE_USERNAME`, `TWINE_REPOSITORY`, and `TWINE_REPOSITORY_URL` environment variables.


## Checklist
<!--- We appreciate your help and please add yourself to the AUTHORS file. -->
The `AUTHORS.rst` file has been updated accordingly.