### PR TITLE
Add decorator to tests which require internet connection.

### DIFF
--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -39,6 +39,7 @@ def test_cwd():
         ) in result.output
 
 
+@requires_internet
 def test_package():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -65,6 +66,7 @@ def test_package():
         ) in result.output
 
 
+@requires_internet
 def test_local():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -102,6 +104,7 @@ def test_local_not_exist():
         assert 'There are no local packages available.' in result.output
 
 
+@requires_internet
 def test_local_multiple():
     with temp_chdir() as d:
         runner = CliRunner()

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -11,7 +11,7 @@ from hatch.settings import (
 )
 from hatch.utils import create_file, temp_chdir, temp_move_path
 from hatch.venv import create_venv, venv
-from ..utils import matching_file
+from ..utils import matching_file, requires_internet
 
 
 def format_files(d):

--- a/tests/commands/test_clean.py
+++ b/tests/commands/test_clean.py
@@ -6,6 +6,7 @@ from hatch.cli import hatch
 from hatch.env import install_packages
 from hatch.utils import create_file, temp_chdir
 from hatch.venv import create_venv, venv
+from ..utils import requires_internet
 
 
 def find_all_files(d):

--- a/tests/commands/test_clean.py
+++ b/tests/commands/test_clean.py
@@ -173,6 +173,7 @@ def test_compiled_only_project_venv_no_detect():
         assert_files_exist(files)
 
 
+@requires_internet
 def test_package():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -214,6 +215,7 @@ def test_package_not_exist():
         assert '`{}` is not an editable package.'.format('ok') in result.output
 
 
+@requires_internet
 def test_local():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -254,6 +256,7 @@ def test_local_not_exist():
         assert 'There are no local packages available.' in result.output
 
 
+@requires_internet
 def test_local_multiple():
     with temp_chdir() as d:
         runner = CliRunner()

--- a/tests/commands/test_env.py
+++ b/tests/commands/test_env.py
@@ -175,6 +175,7 @@ def test_list_success_2():
         ) in result.output
 
 
+@requires_internet
 def test_list_success_3():
     with temp_chdir():
         runner = CliRunner()

--- a/tests/commands/test_grow.py
+++ b/tests/commands/test_grow.py
@@ -148,6 +148,7 @@ def test_init_cwd():
         assert '0.0.1 -> 0.0.2' in result.output
 
 
+@requires_internet
 def test_package():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -184,6 +185,7 @@ def test_package_not_exist():
         assert '`{}` is not an editable package.'.format('ok') in result.output
 
 
+@requires_internet
 def test_local():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -219,6 +221,7 @@ def test_local_not_exist():
         assert 'There are no local packages available.' in result.output
 
 
+@requires_internet
 def test_local_multiple():
     with temp_chdir() as d:
         runner = CliRunner()

--- a/tests/commands/test_grow.py
+++ b/tests/commands/test_grow.py
@@ -10,7 +10,7 @@ from hatch.settings import (
 )
 from hatch.utils import basepath, temp_chdir, temp_move_path
 from hatch.venv import create_venv, venv
-from ..utils import read_file, wait_for_os
+from ..utils import read_file, wait_for_os, requires_internet
 
 
 def test_invalid_part():

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -12,7 +12,7 @@ from hatch.settings import (
 )
 from hatch.utils import create_file, remove_path, temp_chdir, temp_move_path
 from hatch.venv import create_venv, get_new_venv_name, is_venv, venv
-from ..utils import matching_file, read_file, wait_until
+from ..utils import matching_file, read_file, wait_until, requires_internet
 
 
 def test_config_not_exist():

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -82,6 +82,7 @@ def test_output():
         assert 'Created project `new-project` here' in result.output
 
 
+@requires_internet
 def test_env():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -211,6 +212,7 @@ def test_extras():
         assert not os.path.exists(os.path.join(d, 'file.py'))
 
 
+@requires_internet
 def test_envs():
     with temp_chdir():
         runner = CliRunner()

--- a/tests/commands/test_install.py
+++ b/tests/commands/test_install.py
@@ -10,6 +10,7 @@ from hatch.venv import create_venv, get_new_venv_name, is_venv, venv
 from ..utils import requires_internet, wait_for_os, wait_until
 
 
+@requires_internet
 def test_project_no_venv():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -35,6 +36,7 @@ def test_project_no_venv():
         assert 'Installing for this project...' in result.output
 
 
+@requires_internet
 def test_project_existing_venv():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -58,6 +60,7 @@ def test_project_existing_venv():
         assert 'Installing for this project...' in result.output
 
 
+@requires_internet
 def test_project_not_detected_when_venv_active():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -77,6 +80,7 @@ def test_project_not_detected_when_venv_active():
         assert 'Installing...' in result.output
 
 
+@requires_internet
 def test_local():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -93,6 +97,7 @@ def test_local():
         assert result.exit_code == 0
 
 
+@requires_internet
 def test_local_editable():
     with temp_chdir() as d:
         runner = CliRunner()

--- a/tests/commands/test_new.py
+++ b/tests/commands/test_new.py
@@ -12,7 +12,7 @@ from hatch.settings import (
 )
 from hatch.utils import create_file, remove_path, temp_chdir, temp_move_path
 from hatch.venv import create_venv, get_new_venv_name, is_venv, venv
-from ..utils import matching_file, read_file, wait_until
+from ..utils import matching_file, read_file, wait_until, requires_internet
 
 
 def test_config_not_exist():

--- a/tests/commands/test_new.py
+++ b/tests/commands/test_new.py
@@ -93,6 +93,7 @@ def test_already_exists():
         assert 'Directory `{}` already exists.'.format(d) in result.output
 
 
+@requires_internet
 def test_env():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -226,6 +227,7 @@ def test_extras():
         assert not os.path.exists(os.path.join(d, 'file.py'))
 
 
+@requires_internet
 def test_envs():
     with temp_chdir():
         runner = CliRunner()

--- a/tests/commands/test_release.py
+++ b/tests/commands/test_release.py
@@ -124,6 +124,7 @@ def test_local_not_exist():
         assert 'There are no local packages available.' in result.output
 
 
+@requires_internet
 def test_local_multiple():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -329,6 +330,7 @@ def test_repository_env_vars():
         assert result.exit_code == 0
 
 
+@requires_internet
 def test_repository_and_test():
     with temp_chdir() as d:
         runner = CliRunner()

--- a/tests/commands/test_test.py
+++ b/tests/commands/test_test.py
@@ -183,6 +183,7 @@ def test_project_no_venv_coverage_merge():
         assert result.output.strip().endswith(' 100%')
 
 
+@requires_internet
 def test_package():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -217,6 +218,7 @@ def test_package_not_exist():
         assert '`{}` is not an editable package.'.format('ok') in result.output
 
 
+@requires_internet
 def test_local():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -249,6 +251,7 @@ def test_local_not_exist():
         assert 'There are no local packages available.' in result.output
 
 
+@requires_internet
 def test_local_multiple():
     with temp_chdir() as d:
         runner = CliRunner()

--- a/tests/commands/test_uninstall.py
+++ b/tests/commands/test_uninstall.py
@@ -30,6 +30,7 @@ def test_project_no_venv():
         assert 'Uninstalling for this project...' not in result.output
 
 
+@requires_internet
 def test_project_existing_venv():
     with temp_chdir() as d:
         runner = CliRunner()
@@ -59,6 +60,7 @@ def test_project_existing_venv():
         assert 'Uninstalling for this project...' in result.output
 
 
+@requires_internet
 def test_project_not_detected_when_venv_active():
     with temp_chdir() as d:
         runner = CliRunner()

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -33,6 +33,7 @@ def test_get_installed_packages_no_editable():
             assert 'ok' not in packages
 
 
+@requires_internet
 def test_get_editable_package_location():
     with temp_chdir() as d:
         runner = CliRunner()


### PR DESCRIPTION
Hello.

I found out that some tests newly require internet and therefore they have to be skipped in an environment without the internet connection.

The latest virtualenv bundles pip 10.0.1. Pip from version 10.0.0 has support for pyproject.toml files (PEP 518) which means that pip now installs build dependencies specified in pyproject.toml file automatically. And it doesn't work without internet obviously.

It would be nice if you can do a release so it would be possible for me to drop downstream patch. Currently, I had to create this patch twice - once for this PR and once for currently released version 0.20.0.

Have a nice day.
Lumír