### PR TITLE
Avoid installing tests as a package

### DIFF
--- a/hatch/files/setup.py
+++ b/hatch/files/setup.py
@@ -43,7 +43,7 @@ kwargs = {{
         'Programming Language :: Python :: Implementation :: CPython',{pypy}    ],
     'install_requires': REQUIRES,
     'tests_require': ['coverage', 'pytest'],
-    'packages': find_packages(),{entry_point}
+    'packages': find_packages(exclude=('tests',)),{entry_point}
 }}
 
 #################### BEGIN USER OVERRIDES ####################

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     setup_requires=('appdirs', 'atomicwrites'),
     tests_require=('parse', ),
 
-    packages=find_packages(),
+    packages=find_packages(exclude=('tests',)),
     entry_points={
         'console_scripts': (
             'hatch = hatch.cli:hatch',


### PR DESCRIPTION
What the title says. Without this, any Hatch-maintained package (including Hatch itself) would, in addition to installing the package code, litter the `site-packages` directory with a `tests` package, which could potentially conflict with other packages.