### PR TITLE
setup.py: Use OR to indicate MIT or Apache-2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     maintainer='Ofek Lev',
     maintainer_email='ofekmeister@gmail.com',
     url='https://github.com/ofek/hatch',
-    license='MIT/Apache-2.0',
+    license='MIT or Apache-2.0',
 
     keywords=(
         'productivity',


### PR DESCRIPTION
Using `/` is not ambiguous, however `or` is more clear
and is syntax recognised by packaging tools.
