### PR TITLE
Avoid installing tests as a package

### DIFF
--- a/hatch/files/setup.py
+++ b/hatch/files/setup.py
@@ -43,7 +43,7 @@ kwargs = {{
         'Programming Language :: Python :: Implementation :: CPython',{pypy}    ],
     'install_requires': REQUIRES,
     'tests_require': ['coverage', 'pytest'],
-    'packages': find_packages(),{entry_point}
+    'packages': find_packages(exclude=('tests', 'tests.*')),{entry_point}
 }}
 
 #################### BEGIN USER OVERRIDES ####################


### PR DESCRIPTION
## Description
Prevent setup.py from adding a package for `tests`.
<!--- A few words to describe your changes -->

This is a fixed version of https://github.com/ofek/hatch/pull/60 , which was abandoned.