### PR TITLE
Inline TOML tables require = between key/value pairs

### DIFF
--- a/docs/config/metadata.md
+++ b/docs/config/metadata.md
@@ -67,7 +67,7 @@ The full description of the project.
         ```
 
     === "Complex"
-        The `content_type` field must be set to `text/markdown` or `text/x-rst`.
+        The `content-type` field must be set to `text/markdown` or `text/x-rst`.
 
         === "File"
             A `charset` field may also be set to instruct which encoding to
@@ -76,16 +76,16 @@ The full description of the project.
             ```toml
             [project]
             ...
-            readme = {"file": "README.md", "content_type": "text/markdown"}
+            readme = {"file" = "README.md", "content-type" = "text/markdown"}
             ```
 
         === "Text"
-            The `content_type` field must be set to `text/markdown` or `text/x-rst`.
+            The `content-type` field must be set to `text/markdown` or `text/x-rst`.
 
             ```toml
             [project]
             ...
-            readme = {"text": "...", "content_type": "text/markdown"}
+            readme = {"text" = "...", "content-type" = "text/markdown"}
             ```
 
 !!! note


### PR DESCRIPTION
## Description
TOML requires that inline tables (`{}`) connect key/value pairs with equal signs (`=`).

Also fix the spelling of content-type. While the Python code uses `content_type` to refer to the attribute, the specification itself needs `content-type`.

This was not caught by the tests, since they specify it Python type-style to the test runner. A suggestion for the future would be to remove the inline test "file" (in e.g. `test_core.py` and `test_utils.py`) and work with real files (or stringified versions thereof).