### PR TITLE
Add requires_internet mark to additional tests

### DIFF
--- a/tests/cli/build/test_build.py
+++ b/tests/cli/build/test_build.py
@@ -1033,6 +1033,7 @@ def test_debug_verbosity(hatch, temp_dir, helpers):
 
 
 @pytest.mark.allow_backend_process
+@pytest.mark.requires_internet
 def test_shipped(hatch, temp_dir, helpers):
     project_name = 'My App'
 
@@ -1070,6 +1071,7 @@ def test_shipped(hatch, temp_dir, helpers):
 
 
 @pytest.mark.allow_backend_process
+@pytest.mark.requires_internet
 def test_build_dependencies(hatch, temp_dir, helpers):
     project_name = 'My App'
 

--- a/tests/cli/env/test_create.py
+++ b/tests/cli/env/test_create.py
@@ -1,3 +1,5 @@
+import pytest
+
 from hatch.config.constants import AppEnvVars, ConfigEnvVars
 from hatch.project.core import Project
 from hatch.utils.structures import EnvVars
@@ -703,6 +705,7 @@ def test_incompatible_matrix_partial(hatch, helpers, temp_dir, config_file):
     assert env_dirs[0].name == 'test.42'
 
 
+@pytest.mark.requires_internet
 def test_install_project_default_dev_mode(
     hatch, helpers, temp_dir, platform, config_file, default_virtualenv_installed_packages
 ):
@@ -767,6 +770,7 @@ def test_install_project_default_dev_mode(
         assert lines[2].lower() == f'-e {str(project_path).lower()}'
 
 
+@pytest.mark.requires_internet
 def test_install_project_no_dev_mode(
     hatch, helpers, temp_dir, platform, config_file, default_virtualenv_installed_packages
 ):
@@ -830,6 +834,7 @@ def test_install_project_no_dev_mode(
         assert lines[0].startswith('my-app @')
 
 
+@pytest.mark.requires_internet
 def test_pre_install_commands(hatch, helpers, temp_dir, config_file):
     config_file.model.template.plugins['default']['tests'] = False
     config_file.save()
@@ -906,6 +911,7 @@ def test_pre_install_commands_error(hatch, helpers, temp_dir, config_file):
     )
 
 
+@pytest.mark.requires_internet
 def test_post_install_commands(hatch, helpers, temp_dir, config_file):
     config_file.model.template.plugins['default']['tests'] = False
     config_file.save()
@@ -946,6 +952,7 @@ def test_post_install_commands(hatch, helpers, temp_dir, config_file):
     assert (project_path / 'test.txt').is_file()
 
 
+@pytest.mark.requires_internet
 def test_post_install_commands_error(hatch, helpers, temp_dir, config_file):
     config_file.model.template.plugins['default']['tests'] = False
     config_file.save()
@@ -983,6 +990,7 @@ def test_post_install_commands_error(hatch, helpers, temp_dir, config_file):
     )
 
 
+@pytest.mark.requires_internet
 def test_sync_dependencies(hatch, helpers, temp_dir, platform, config_file, default_virtualenv_installed_packages):
     config_file.model.template.plugins['default']['tests'] = False
     config_file.save()
@@ -1058,6 +1066,7 @@ def test_sync_dependencies(hatch, helpers, temp_dir, platform, config_file, defa
         assert lines[3].lower() == f'-e {str(project_path).lower()}'
 
 
+@pytest.mark.requires_internet
 def test_features(hatch, helpers, temp_dir, platform, config_file, default_virtualenv_installed_packages):
     config_file.model.template.plugins['default']['tests'] = False
     config_file.save()

--- a/tests/cli/env/test_prune.py
+++ b/tests/cli/env/test_prune.py
@@ -1,3 +1,5 @@
+import pytest
+
 from hatch.config.constants import AppEnvVars
 from hatch.project.core import Project
 
@@ -31,6 +33,7 @@ def test_unknown_type(hatch, helpers, temp_dir_data, config_file):
     )
 
 
+@pytest.mark.requires_internet
 def test_all(hatch, helpers, temp_dir_data, config_file, default_virtualenv_installed_packages):
     project_name = 'My App'
 

--- a/tests/cli/env/test_remove.py
+++ b/tests/cli/env/test_remove.py
@@ -1,3 +1,5 @@
+import pytest
+
 from hatch.config.constants import AppEnvVars
 from hatch.project.core import Project
 
@@ -40,6 +42,7 @@ def test_nonexistent(hatch, temp_dir_data, config_file):
     assert not result.output
 
 
+@pytest.mark.requires_internet
 def test_single(hatch, helpers, temp_dir_data, config_file):
     project_name = 'My App'
 
@@ -98,6 +101,7 @@ def test_single(hatch, helpers, temp_dir_data, config_file):
     assert not bar_env_path.is_dir()
 
 
+@pytest.mark.requires_internet
 def test_all(hatch, helpers, temp_dir_data, config_file):
     project_name = 'My App'
 
@@ -161,6 +165,7 @@ def test_all(hatch, helpers, temp_dir_data, config_file):
     assert not storage_path.is_dir()
 
 
+@pytest.mark.requires_internet
 def test_matrix_all(hatch, helpers, temp_dir_data, config_file):
     project_name = 'My App'
 
@@ -255,6 +260,7 @@ def test_active(hatch, temp_dir_data, helpers, config_file):
     )
 
 
+@pytest.mark.requires_internet
 def test_active_override(hatch, helpers, temp_dir_data, config_file):
     project_name = 'My App'
 

--- a/tests/cli/run/test_run.py
+++ b/tests/cli/run/test_run.py
@@ -1,5 +1,7 @@
 import sys
 
+import pytest
+
 from hatch.config.constants import AppEnvVars, ConfigEnvVars
 from hatch.project.core import Project
 from hatch.utils.structures import EnvVars
@@ -119,6 +121,7 @@ def test_enter_project_directory(hatch, config_file, helpers, temp_dir):
     assert str(env_path) in str(output_file.read_text())
 
 
+@pytest.mark.requires_internet
 def test_sync_dependencies(hatch, helpers, temp_dir, config_file):
     config_file.model.template.plugins['default']['tests'] = False
     config_file.save()
@@ -313,6 +316,7 @@ def test_scripts_specific_environment(hatch, helpers, temp_dir, config_file):
     assert env_var_value == 'bar'
 
 
+@pytest.mark.requires_internet
 def test_scripts_no_environment(hatch, temp_dir, config_file):
     config_file.model.template.plugins['default']['tests'] = False
     config_file.save()


### PR DESCRIPTION
In an offline build environment, all of the following tests fail with something like:

```
E       AssertionError: Creating environment: foo.9000
E         Syncing dependencies
E         
E       assert 1 == 0
E        +  where 1 = <Result SystemExit(1)>.exit_code

/builddir/build/BUILD/hatch-hatch-v1.0.0rc16/tests/cli/env/test_remove.py:181: AssertionError
----------------------------- Captured stderr call -----------------------------
WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f629447d990>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution')': /simple/pytest/
WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f629447c640>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution')': /simple/pytest/
WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f629447c850>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution')': /simple/pytest/
WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f629447ffd0>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution')': /simple/pytest/
WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f629447ded0>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution')': /simple/pytest/
ERROR: Could not find a version that satisfies the requirement pytest (from versions: none)
ERROR: No matching distribution found for pytest
```

which implies that these tests need to install wheels from PyPI.

```
FAILED tests/cli/env/test_create.py::test_post_install_commands - AssertionEr...
FAILED tests/cli/env/test_create.py::test_features - AssertionError: Creating...
FAILED tests/cli/env/test_create.py::test_post_install_commands_error - asser...
FAILED tests/cli/env/test_create.py::test_sync_dependencies - AssertionError:...
FAILED tests/cli/env/test_create.py::test_install_project_no_dev_mode - Asser...
FAILED tests/cli/env/test_create.py::test_install_project_default_dev_mode - ...
FAILED tests/cli/env/test_create.py::test_pre_install_commands - AssertionErr...
FAILED tests/cli/run/test_run.py::test_sync_dependencies - AssertionError: Sy...
FAILED tests/cli/run/test_run.py::test_scripts_no_environment - AssertionErro...
FAILED tests/cli/env/test_prune.py::test_all - AssertionError: Creating envir...
FAILED tests/cli/build/test_build.py::test_shipped - AssertionError: Setting ...
FAILED tests/cli/build/test_build.py::test_build_dependencies - AssertionErro...
FAILED tests/cli/env/test_remove.py::test_active_override - AssertionError: C...
FAILED tests/cli/env/test_remove.py::test_all - AssertionError: Creating envi...
FAILED tests/cli/env/test_remove.py::test_single - AssertionError: Creating e...
FAILED tests/cli/env/test_remove.py::test_matrix_all - AssertionError: Creati...
```

Add the `@pytest.mark.requires_internet` decorator, previously used only for `tests/cli/new/test_new.py::test_default_no_license_cache`, to these tests.

https://github.com/ofek/hatch/issues/120#issuecomment-1074661928